### PR TITLE
Github -> Framapad links

### DIFF
--- a/assets/localizations/markdowns/en_US/page_help_body.md
+++ b/assets/localizations/markdowns/en_US/page_help_body.md
@@ -1,6 +1,6 @@
 Here are some useful links to find help with GLF OS:
 
 * [GLF OS Page](https://www.gaminglinux.fr/glf-os/)
-* [Our Documentation](https://github.com/Gaming-Linux-FR/GLF-OS/wiki/Home_EN)
-* [Our GitHub](https://github.com/Gaming-Linux-FR/GLF-OS/)
+* [Our Documentation](https://framagit.org/gaming-linux-fr/glf-os/glf-os/-/wikis/Home_EN)
+* [Our Git](https://framagit.org/gaming-linux-fr/glf-os/glf-os)
 * [Our Discord](https://discord.gg/tqXyUMEwq3)

--- a/assets/localizations/markdowns/fr_FR/page_help_body.md
+++ b/assets/localizations/markdowns/fr_FR/page_help_body.md
@@ -1,6 +1,6 @@
 Voici quelques liens utiles pour trouver de l'aide sur GLF OS :
 
 -  [Page GLF OS](https://www.gaminglinux.fr/glf-os/)
--  [Notre documentation](https://github.com/Gaming-Linux-FR/GLF-OS/wiki)
--  [Notre Github](https://github.com/Gaming-Linux-FR/GLF-OS/)
+-  [Notre documentation](https://framagit.org/gaming-linux-fr/glf-os/glf-os/-/wikis/home)
+-  [Notre Git](https://framagit.org/gaming-linux-fr/glf-os/glf-os)
 -  [Notre Discord](https://discord.gg/tqXyUMEwq3)


### PR DESCRIPTION
Change links in the help section from Github to Framapad (FR + EN)